### PR TITLE
proof-of-concept decode XLS from ByteString

### DIFF
--- a/bin/xls2csv.hs
+++ b/bin/xls2csv.hs
@@ -3,6 +3,7 @@
 
 import Data.List (intercalate)
 import Data.Xls (decodeXlsIO)
+import Data.XlsCell (cellToString)
 import WithCli (withCli)
 
 -- TODO need to escape the separator and the escaping quotes themselves
@@ -10,7 +11,7 @@ import WithCli (withCli)
 xlsToCSV :: String -> IO ()
 xlsToCSV file = do
     worksheets <- decodeXlsIO file
-    mapM_ (mapM_ (putStrLn . intercalate ",")) worksheets
+    mapM_ (mapM_ (putStrLn . intercalate "," . fmap cellToString)) worksheets
 
 main :: IO ()
 main = withCli xlsToCSV

--- a/lib/Data/Xls.hs
+++ b/lib/Data/Xls.hs
@@ -21,22 +21,32 @@
 
 module Data.Xls
     ( decodeXlsIO
+    , decodeXlsByteString
+    , decodeXlsByteString'
     , decodeXls
     , XlsException(..)
+    , XLSError(..)
     )
 where
 
-import           Control.Exception (Exception, throwIO, bracket)
+import           Control.Exception (Exception, throwIO, bracket, catch)
 import           Control.Monad.IO.Class
-import           Control.Monad (when, void)
+import           Control.Monad (void)
 import           Control.Monad.Trans.Resource
 import           Data.Conduit hiding (Conduit, Sink, Source)
 import           Data.Data
 import           Data.Int
+import           Data.Word (Word32)
 import           Data.Maybe (catMaybes, fromJust, isJust, fromMaybe)
+import           Data.ByteString (hPut)
+import           Data.ByteString.Internal (ByteString(..))
 import           Foreign.C
 import           Foreign.Ptr
+import           Foreign.ForeignPtr (withForeignPtr)
+import           Foreign.Storable (Storable(..))
+import           Foreign.Marshal.Alloc (malloc)
 import           Text.Printf
+import           System.IO.Temp (withSystemTempFile)
 
 #define CCALL(name,signature) \
 foreign import ccall unsafe #name \
@@ -44,9 +54,43 @@ foreign import ccall unsafe #name \
 
 -- Workbook accessor functions
 data XLSWorkbookStruct
+-- | An enum returned by libxls. See libxls\/include\/xls.h
+data XLSError = LIBXLS_OK 
+    | LIBXLS_ERROR_OPEN 
+    | LIBXLS_ERROR_SEEK 
+    | LIBXLS_ERROR_READ 
+    | LIBXLS_ERROR_PARSE 
+    | LIBXLS_ERROR_MALLOC
+    deriving (Show,Eq,Enum)
+instance Storable XLSError where
+    sizeOf = const (sizeOf (0 :: Word32)) -- TODO: sizeof enum is compiler and architecture dependent!
+    alignment = sizeOf -- okay for simple Storables
+    peek = fmap (toEnum . (fromIntegral :: Word32 -> Int)) . peek . castPtr
+    poke ptr e = poke (castPtr ptr) ((fromIntegral :: Int -> Word32).fromEnum $ e)
 type XLSWorkbook = Ptr XLSWorkbookStruct
+type XLSErrorT = Ptr XLSError
+type CBuffer = Ptr CUChar
+
+-- | Recall that
+-- @
+-- ByteString ~ (ForeignPtr Char8,Int)
+--     CUChar ~ Word8
+--      CSize ~ Word64
+-- @
+--
+-- So we need to marshal
+-- 
+-- @
+-- (ForeignPtr Char8) -> Ptr CUChar
+-- Int -> CSize
+-- @
+toCBuffer :: ByteString -> IO (CBuffer,CSize)
+toCBuffer (PS fPtr offset ilen) = do
+    withForeignPtr fPtr $ \ptrData -> do
+        return (plusPtr (castPtr ptrData) offset,CSize (fromIntegral ilen))
 
 CCALL(xls_open,          CString -> CString -> IO XLSWorkbook)
+CCALL(xls_open_buffer,   CBuffer -> CSize -> CString -> XLSErrorT -> IO XLSWorkbook)
 CCALL(xls_wb_sheetcount, XLSWorkbook -> IO CInt -- Int32)
 CCALL(xls_close_WB,      XLSWorkbook -> IO ())
 
@@ -82,6 +126,13 @@ data XlsException =
 
 instance Exception XlsException
 
+exceptionLeft :: XlsException -> Either XLSError a
+exceptionLeft (XlsFileNotFound _) = Left LIBXLS_ERROR_OPEN
+exceptionLeft (XlsParseError   _) = Left LIBXLS_ERROR_PARSE
+
+catchXls :: IO a -> IO (Either XLSError a)
+catchXls = flip catch (return.exceptionLeft) . fmap Right 
+
 -- | Parse a Microsoft excel xls workbook file into a Conduit yielding
 -- rows in a worksheet. Each row represented by a list of Strings, each String
 -- representing an individual cell.
@@ -111,6 +162,27 @@ decodeXls file =
             count <- liftIO $ c_xls_wb_sheetcount pWB
             mapM_ (decodeOneWorkSheet file pWB) [0 .. count - 1]
 
+-- | A work-around via temporary files and 'decodeXlsIO', 
+-- since this lib is lacking a pure function to decode the contents 
+-- of an XLS file. 
+-- Due to Erik Rybakken. 
+decodeXlsByteString :: ByteString -> IO [[[String]]]
+decodeXlsByteString content = withSystemTempFile "decodeXlsByteString"
+    $ \filePath h -> do
+        hPut h content
+        decodeXlsIO filePath
+
+-- | Experimental: This function uses the @xls_open_buffer@ function of libxls.
+decodeXlsByteString' :: ByteString -> IO (Either XLSError [[[String]]])
+decodeXlsByteString' bs = do
+    (buf,buflen) <- toCBuffer bs
+    enc <- newCString "UTF-8"
+    outError <- malloc
+    wb <- c_xls_open_buffer buf buflen enc outError
+    e <- peek outError
+    case e of
+        LIBXLS_OK -> decodeXLSWorkbook Nothing wb
+        _         -> return (Left e) 
 
 -- | Parse a Microsoft excel xls workbook file into a list of worksheets, each
 -- worksheet consists of a list of rows and each row consists of a list of
@@ -124,13 +196,25 @@ decodeXlsIO
 decodeXlsIO file = do
     file' <- newCString file
     pWB <- newCString "UTF-8" >>= c_xls_open file'
-    when (pWB == nullPtr) $
-        throwIO $ XlsFileNotFound
-                $ "XLS file " ++ file ++ " not found."
-    count <- liftIO $ c_xls_wb_sheetcount pWB
-    results <- mapM (decodeOneWorkSheetIO file pWB) [0 .. count - 1]
-    void $ c_xls_close_WB pWB
-    return results
+    parseResult <- decodeXLSWorkbook (Just file) pWB
+    case parseResult of
+        Right results -> return results
+        Left  e -> case e of
+            LIBXLS_ERROR_OPEN -> throwIO $ XlsFileNotFound $ 
+                "XLS file " ++ file ++ " not found."
+            _                 -> throwIO $ XlsParseError $ 
+                "XLS file " ++ file ++ " could not be parsed."
+
+-- helper function for decoding both file and buffer
+decodeXLSWorkbook :: Maybe FilePath -> XLSWorkbook -> IO (Either XLSError [[[String]]])
+decodeXLSWorkbook mFile pWB = if pWB == nullPtr
+    then return (Left LIBXLS_ERROR_OPEN)
+    else catchXls $ do 
+        count <- liftIO $ c_xls_wb_sheetcount pWB
+        results <- mapM (decodeOneWorkSheetIO (maybe "buffer" id mFile) pWB) [0 .. count - 1]
+        void $ c_xls_close_WB pWB
+        return results
+    
 
 decodeOneWorkSheet
     :: MonadResource m

--- a/lib/Data/XlsCell.hs
+++ b/lib/Data/XlsCell.hs
@@ -19,7 +19,7 @@ data CellF o = NumericalCell Double
     | TextCell String
     | BoolCell Bool 
     | OtherCell o
-    deriving (Functor)
+    deriving (Functor,Show,Eq)
 instance IsString (CellF o) where
     fromString = TextCell
 

--- a/lib/Data/XlsCell.hs
+++ b/lib/Data/XlsCell.hs
@@ -1,0 +1,35 @@
+-- |
+-- Module      : Data.XlsCell
+-- Copyright   : (c) 2022 Olaf.Klinke
+--
+-- License     : BSD-style
+-- Maintainer  : olaf.klinke@phymetric.de
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Static Excel cell values
+--
+{-# LANGUAGE DeriveFunctor, FlexibleInstances #-}
+module Data.XlsCell (CellF(..),Cell,cellToString) where
+import Data.String (IsString(..))
+import Text.Printf (printf)
+
+-- | extensible 'Cell' type
+data CellF o = NumericalCell Double
+    | TextCell String
+    | BoolCell Bool 
+    | OtherCell o
+    deriving (Functor)
+instance IsString (CellF o) where
+    fromString = TextCell
+
+-- | static 'Cell's in Excel files can hold 
+-- numbers, test or booleans. 
+type Cell = CellF ()
+
+-- | convert to 'String'. Not the inverse of 'fromString'!
+cellToString :: Cell -> String
+cellToString (NumericalCell d) = printf "%.15g" d
+cellToString (TextCell txt) = txt
+cellToString (BoolCell b) = if b then "True" else "False"
+cellToString (OtherCell _) = ""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,5 @@
 import           Data.Xls
+import           Data.XlsCell (CellF(..),Cell)
 import           Test.Hspec
 
 main :: IO ()
@@ -7,5 +8,8 @@ main = hspec $ describe "Sanity check" $ do
         content <- decodeXlsIO "test/data/test.xls"
         content `shouldBe` testFileContent
 
-testFileContent :: [[[String]]]
-testFileContent = [[["1.000000000000000","2.3","text"]],[["1.000000000000000","2.3","text"]]]
+testFileContent :: [[[Cell]]]
+testFileContent = [
+    [[NumericalCell 1.0,TextCell "2.3",TextCell "text"]],
+    [[NumericalCell 1.0,TextCell "2.3",TextCell "text"]]
+    ]

--- a/xls.cabal
+++ b/xls.cabal
@@ -1,5 +1,5 @@
 name:                xls
-version:             0.1.3
+version:             0.1.4
 synopsis:            Parse Microsoft Excel xls files (BIFF/Excel 97-2004)
 description:
  Parse Microsoft Excel spreadsheet files in @.xls@ file format
@@ -50,9 +50,11 @@ library
   hs-source-dirs:      lib
   exposed-modules:     Data.Xls
   build-depends:       base         >= 4.7   && < 5
+                     , bytestring   >= 0.10
                      , conduit      >= 1.1   && < 1.4
                      , filepath     >= 1.0   && < 1.5
                      , resourcet    >= 0.3   && < 1.3
+                     , temporary
                      , transformers >= 0.1   && < 0.6
 
   c-sources:           lib/libxls-wrapper.c,

--- a/xls.cabal
+++ b/xls.cabal
@@ -49,6 +49,7 @@ library
 
   hs-source-dirs:      lib
   exposed-modules:     Data.Xls
+                     , Data.XlsCell
   build-depends:       base         >= 4.7   && < 5
                      , bytestring   >= 0.10
                      , conduit      >= 1.1   && < 1.4


### PR DESCRIPTION
I added two functions to decode a `ByteString`. The function `decodeXlsByteString` is just a wrapper around `decodeXlsIO` as suggested by [Erik Rybakken](https://github.com/harendra-kumar/xls/issues/6#issuecomment-644568078). The function `decodeXlsByteString'` makes use of the libxls function that can open buffers. The latter is experimental and when proven to work properly should replace the former. Since this is my first FFI project, someone please review the definition of `Data.Xls.toCBuffer` and the `Storable XLSError` instance. Specifically, how does one determine the correct `sizeOf` a C enum? On my machine, `sizeof(xls_error_t)` returns 4 with gcc, but that might be different with different compiler/architecture combinations.