### PR TITLE
bump version bounds

### DIFF
--- a/xls.cabal
+++ b/xls.cabal
@@ -52,8 +52,8 @@ library
   build-depends:       base         >= 4.7   && < 5
                      , conduit      >= 1.1   && < 1.4
                      , filepath     >= 1.0   && < 1.5
-                     , resourcet    >= 0.3   && < 1.3
-                     , transformers >= 0.1   && < 0.6
+                     , resourcet    >= 0.3   && < 1.4
+                     , transformers >= 0.1   && < 0.7
 
   c-sources:           lib/libxls-wrapper.c,
                        lib/libxls/src/xlstool.c,
@@ -71,8 +71,8 @@ executable xls2csv
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   build-depends:        base            >= 4.7   && < 5
                       , conduit         >= 1.1   && < 1.4
-                      , resourcet       >= 0.3   && < 1.3
-                      , transformers    >= 0.1   && < 0.6
+                      , resourcet       >= 0.3   && < 1.4
+                      , transformers    >= 0.1   && < 0.7
                       , getopt-generics >= 0.11  && < 0.14
                       , xls
 


### PR DESCRIPTION
Current transformers changelog is [here](https://hackage.haskell.org/package/transformers-0.6.1.1/changelog) but the breaking change is:

> 0.6.0.0 Ross Paterson <R.Paterson@city.ac.uk> Jul 2021
	* Added quantified constraint to MonadTrans (for GHC >= 8.6)
	* Added Generic and Data instances
	* Added handleE, tryE and finallyE to Control.Monad.Trans.Except
	* Added hoistMaybe to Control.Monad.Trans.Maybe
	* Added Generic and Data instances
	* Added pass-throughs to instances for Backwards
	* Made Lift's <*> lazier
	* Remove long-deprecated selectToCont
	* Remove long-deprecated Control.Monad.Trans.Error
	* Remove long-deprecated Control.Monad.Trans.List

For resourcet it's [here](https://hackage.haskell.org/package/resourcet-1.3.0/changelog) and just:

> ## 1.3.0
>
> * Include the exception in ReleaseTypes indicating exceptional exit.
>
>    Only backwards-incompatible in code relying on instances of ReleaseType
>    other than Show, or constructing ReleaseException directly.

I didn't look too closely at the code to confirm these didn't apply, but the test suite runs OK.